### PR TITLE
Added functionality to find connected MCP2210 devices

### DIFF
--- a/mcp2210/mcp2210.py
+++ b/mcp2210/mcp2210.py
@@ -24,6 +24,23 @@ def bytes_to_hex_string(data: bytes) -> str:
     """
     return ' '.join("{:02X}".format(x) for x in data)
 
+def find_connected_mcp2210() -> list[str]:
+    """
+    Searches for connected MCP2210 devices and returns their serial numbers.
+
+    Returns:
+        list[str]: A list of serial numsbers of available MCP2210 devices.
+    """
+    connected_mcps: list[str] = []
+
+    try:
+        for hid_handler in hid.enumerate(vendor_id = 0x04d8, product_id = 0x00de):
+            connected_mcps.append(hid_handler['serial_number'])
+    except Exception as e:
+        print(f"Error finding connected MCP2210 devices: {e}")
+        return []
+
+    return connected_mcps
 
 class Mcp2210Commands(IntEnum):
     """


### PR DESCRIPTION
This pull request adds a new function, find_connected_mcp2210(), which searches for connected MCP2210 devices and returns their serial numbers. This function iterates over all HID devices with vendor ID 0x04d8 and product ID 0x00de, appends the serial number of each device to a list, and returns the list. If no devices are found, an empty list is returned.