### PR TITLE
Improved compatibility, added find_connected_mcp2210 to __init__.py

### DIFF
--- a/mcp2210/__init__.py
+++ b/mcp2210/__init__.py
@@ -1,2 +1,2 @@
 from .mcp2210 import Mcp2210, Mcp2210GpioDesignation, Mcp2210GpioDirection, Mcp2210CommandFailedException, \
-    Mcp2210SpiBusLockedException, Mcp2210CommandResponseDesyncException, Mcp2210UsbBusyException
+    Mcp2210SpiBusLockedException, Mcp2210CommandResponseDesyncException, Mcp2210UsbBusyException, find_connected_mcp2210

--- a/mcp2210/mcp2210.py
+++ b/mcp2210/mcp2210.py
@@ -24,14 +24,14 @@ def bytes_to_hex_string(data: bytes) -> str:
     """
     return ' '.join("{:02X}".format(x) for x in data)
 
-def find_connected_mcp2210() -> list[str]:
+def find_connected_mcp2210() -> List[str]:
     """
     Searches for connected MCP2210 devices and returns their serial numbers.
 
     Returns:
-        list[str]: A list of serial numsbers of available MCP2210 devices.
+        List[str]: A list of serial numsbers of available MCP2210 devices.
     """
-    connected_mcps: list[str] = []
+    connected_mcps: List[str] = []
 
     try:
         for hid_handler in hid.enumerate(vendor_id = 0x04d8, product_id = 0x00de):


### PR DESCRIPTION
Fixed Python compatibility issue mentioned by @crypto-lars in #8
Added `find_connected_mcp2210` function to `__init__.py` to make it able to import it directly by
```python
from mcp2210 import find_connected_mcp2210
```