### PR TITLE
Added SPI bit rate set function

### DIFF
--- a/mcp2210/mcp2210.py
+++ b/mcp2210/mcp2210.py
@@ -828,4 +828,12 @@ class Mcp2210(object):
 
         self._spi_settings.mode = mode
         self._set_spi_configuration()
-        
+
+    def set_spi_bit_rate(self, bit_rate: int):
+        """
+        Sets the SPI bitrate of the device.
+
+        :param bit_rate: the SPI bitrate, between 1.5kHz and 12MHz.
+        """
+        self._spi_settings.bit_rate = bit_rate
+        self._set_spi_configuration()


### PR DESCRIPTION
There was no function available yet to set the SPI bit rate.

Exposing this setting through the internal `_spi_settings` object as was done for `spi_mode`.